### PR TITLE
Pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,10 @@ all-redacted:
 # it'll wake up, issue its cheery version-header greeting, realize
 # that nothing actually needs to be done, and exit.)
 %.pdf: %.ltx Makefile venv
+	@rm -f $@
 	@${PIPELINE} $< --output $(<:.ltx=.tex)
 	@latexmk -pdf -pdflatex=$(PDFLATEX) -halt-on-error --shell-escape $(<:.ltx=.tex)
+	@rm -f $(@:.pdf=-$(REVBIN).pdf)
 	@mv $@ $(@:.pdf=-$(REVBIN).pdf)
 	@ln -sf $(@:.pdf=-$(REVBIN).pdf) $@
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ all-drafts:
 # it'll wake up, issue its cheery version-header greeting, realize
 # that nothing actually needs to be done, and exit.)
 %.pdf: %.ltx Makefile venv
-	venv/bin/python3 ${JINJIFY} -o draft True $< > $(<:.ltx=.intermediate_ltx)
+	venv/bin/python3 ${JINJIFY} $< > $(<:.ltx=.intermediate_ltx)
 	@latexmk -pdf -pdflatex=$(PDFLATEX) -halt-on-error $(<:.ltx=.intermediate_ltx)
 
 # This builds the draft.  This only works if you're using the a jinja

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,10 @@ LTX_SRCS := $(shell find . -name dd'*.ltx' ! -path './.\#*')
 	venv/bin/python3 ${JINJIFY} -o draft True $< > $(<:.ltx=.intermediate_ltx)
 	@latexmk -pdf -pdflatex=$(PDFLATEX) -halt-on-error $(<:.ltx=.intermediate_ltx)
 
-# This builds the draft.
+# This builds the draft.  This only works if you're using the a jinja
+# template that extends down to base.ltx.  If you're just compiling
+# straight latex, building a draft version is unsupported and leads to
+# undefined behavior.
 %.draft.pdf: %.ltx Makefile venv
 	@if [ -L $(shell basename $< .ltx).draft.pdf ]; then rm $(shell basename $< .ltx).draft.pdf; fi
 	venv/bin/python3 ${JINJIFY} -o draft True $< > $(<:.ltx=.intermediate_ltx) 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ all-redacted:
 # it'll wake up, issue its cheery version-header greeting, realize
 # that nothing actually needs to be done, and exit.)
 %.pdf: %.ltx Makefile venv
-	venv/bin/python3 ${PIPELINE} $< --output $(<:.ltx=.tex)
+	@venv/bin/python3 ${PIPELINE} $< --output $(<:.ltx=.tex)
 	@latexmk -pdf -pdflatex=$(PDFLATEX) -halt-on-error $(<:.ltx=.tex)
 
 # This builds the draft.  This only works if you're using the a jinja
@@ -96,8 +96,8 @@ all-redacted:
 # redacted field in the YAML pre-matter.  That field should specify a
 # string or a list of regexes to bleep in the output.
 %.redacted.ltx: %.ltx Makefile
-	rm -f $@
-	ln -s $< $@
+	@rm -f $@
+	@ln -s $< $@
 
 # OTS Doctools's pipeline needs some python dependencies.  Not sure
 # this is the best place to do this-- it wastes diskspace and clutters

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,7 @@ LTX_SRCS := $(shell find . -name dd'*.ltx' ! -path './.\#*')
 	venv/bin/python3 ${JINJIFY} -o draft True $< > $(<:.ltx=.intermediate_ltx)
 	@latexmk -pdf -pdflatex=$(PDFLATEX) -halt-on-error $(<:.ltx=.intermediate_ltx)
 
-# This builds the draft.  It can handle underscores in the jobname,
-# but will produce spurious "type a command or say \end" notices.
+# This builds the draft.
 %.draft.pdf: %.ltx Makefile venv
 	@if [ -L $(shell basename $< .ltx).draft.pdf ]; then rm $(shell basename $< .ltx).draft.pdf; fi
 	venv/bin/python3 ${JINJIFY} -o draft True $< > $(<:.ltx=.intermediate_ltx) 

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ all-drafts:
 # but no content was changed, then 'latexmk' will run very quickly:
 # it'll wake up, issue its cheery version-header greeting, realize
 # that nothing actually needs to be done, and exit.)
-LTX_SRCS := $(shell find . -name dd'*.ltx' ! -path './.\#*')
-%.pdf: %.ltx Makefile venv #$(LTX_SRCS)
+%.pdf: %.ltx Makefile venv
 	venv/bin/python3 ${JINJIFY} -o draft True $< > $(<:.ltx=.intermediate_ltx)
 	@latexmk -pdf -pdflatex=$(PDFLATEX) -halt-on-error $(<:.ltx=.intermediate_ltx)
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ all-drafts:
 # it's one less thing for a user to think about.
 venv:
 	virtualenv -p python3 venv
-	venv/bin/pip3 install python-frontmatter jinja2
+	venv/bin/pip3 install python-frontmatter jinja2 click
 
 # LaTeX litters a lot
 clean_latex:

--- a/jinja/base.ltx
+++ b/jinja/base.ltx
@@ -2,7 +2,7 @@
 
 \usepackage{ots}
 
-\BLOCK{if draft is defined and draft=='True'}
+\BLOCK{if draft is defined and (draft=='True' or draft==True)}
 \usepackage{draftwatermark}
 \SetWatermarkText{DRAFT}
 \SetWatermarkScale{6}

--- a/jinja/base.ltx
+++ b/jinja/base.ltx
@@ -1,0 +1,131 @@
+\documentclass[12pt]{article}
+
+\usepackage{ots}
+
+\BLOCK{if draft is defined and draft=='True'}
+\usepackage{draftwatermark}
+\SetWatermarkText{DRAFT}
+\SetWatermarkScale{6}
+\BLOCK{endif}
+
+\usepackage{enumerate}
+\ifxetex
+  \usepackage[setpagesize=false, % page size defined by xetex
+              unicode=false, % unicode breaks when used with xetex
+              xetex]{hyperref}
+\else
+  \usepackage[unicode=true]{hyperref}
+\fi
+\hypersetup{breaklinks=true, pdfborder={0 0 0}}
+
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{7pt plus 2pt minus 1pt}
+\setcounter{secnumdepth}{0}
+
+\usepackage[margin=1in]{geometry}
+
+\usepackage{hyperref}
+\usepackage{multicol}  % We use this for the Contact Information section
+
+% Set up the bibliography style
+\usepackage[backend=biber,style=authortitle]{biblatex}  %backend=biber is 'better'
+\addbibresource{bibliography.bib}
+\setlength\bibitemsep{0.5\baselineskip}
+\setlength\bibnamesep{0.5\baselineskip}
+\setlength\bibinitsep{0.5\baselineskip}
+
+
+% For logo and accompanying contact info.
+\usepackage{graphicx}
+\usepackage{float}
+\usepackage{color}
+\definecolor{dkgreen}{RGB}{50, 109, 72}
+\definecolor{dkergreen}{RGB}{0, 100, 0}
+\DeclareFixedFont{\viiisf}{OT1}{cmss}{m}{n}{8}
+\newcommand{\circlesep}{\raisebox{1.7em}{\hspace{1.8em}\includegraphics[clip, trim=0cm 11cm 19.3cm 11cm, scale=0.05]{otslogo.pdf}\hspace{1.8em}}}
+
+\begin{document}
+
+\raggedright
+
+\BLOCK{block letterhead}
+\BLOCK{endblock} %# letterhead
+  
+\BLOCK{block title}
+  \BLOCK{ if title is defined }
+    \begin{center}
+    \LARGE{\VAR{title}}\\
+    \BLOCK{ if date is defined }
+      \vspace{1em}
+      \normalsize{\VAR{date}}
+    \BLOCK{endif}
+  \end{center}
+  \BLOCK{endif}
+\BLOCK{endblock}
+
+\BLOCK{block body}
+  This is default text.
+
+\section{What is Lorem Ipsum?}
+
+Lorem Ipsum is simply dummy text of the printing and typesetting
+industry. Lorem Ipsum has been the industry's standard dummy text ever
+since the 1500s, when an unknown printer took a galley of type and
+scrambled it to make a type specimen book. It has survived not only
+five centuries, but also the leap into electronic typesetting,
+remaining essentially unchanged. It was popularised in the 1960s with
+the release of Letraset sheets containing Lorem Ipsum passages, and
+more recently with desktop publishing software like Aldus PageMaker
+including versions of Lorem Ipsum.
+
+\subsection{Why do we use it?}
+
+It is a long established fact that a reader will be distracted by the
+readable content of a page when looking at its layout. The point of
+using Lorem Ipsum is that it has a more-or-less normal distribution of
+letters, as opposed to using 'Content here, content here', making it
+look like readable English. Many desktop publishing packages and web
+page editors now use Lorem Ipsum as their default model text, and a
+search for 'lorem ipsum' will uncover many web sites still in their
+infancy. Various versions have evolved over the years, sometimes by
+accident, sometimes on purpose (injected humour and the like).
+
+\subsection{Where does it come from?}
+
+Contrary to popular belief, Lorem Ipsum is not simply random text. It
+has roots in a piece of classical Latin literature from 45 BC, making
+it over 2000 years old. Richard McClintock, a Latin professor at
+Hampden-Sydney College in Virginia, looked up one of the more obscure
+Latin words, consectetur, from a Lorem Ipsum passage, and going
+through the cites of the word in classical literature, discovered the
+undoubtable source. Lorem Ipsum comes from sections 1.10.32 and
+1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and
+Evil) by Cicero, written in 45 BC. This book is a treatise on the
+theory of ethics, very popular during the Renaissance. The first line
+of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+section 1.10.32.
+
+The standard chunk of Lorem Ipsum used since the 1500s is reproduced
+below for those interested. Sections 1.10.32 and 1.10.33 from "de
+Finibus Bonorum et Malorum" by Cicero are also reproduced in their
+exact original form, accompanied by English versions from the 1914
+translation by H. Rackham.
+
+\subsection{Where can I get some?}
+
+There are many variations of passages of Lorem Ipsum available, but
+the majority have suffered alteration in some form, by injected
+humour, or randomised words which don't look even slightly
+believable. If you are going to use a passage of Lorem Ipsum, you need
+to be sure there isn't anything embarrassing hidden in the middle of
+text. All the Lorem Ipsum generators on the Internet tend to repeat
+predefined chunks as necessary, making this the first true generator
+on the Internet. It uses a dictionary of over 200 Latin words,
+combined with a handful of model sentence structures, to generate
+Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is
+therefore always free from repetition, injected humour, or
+non-characteristic words etc.  Try https://lipsum.com/
+
+\BLOCK{endblock}%# end body block
+
+\end{document}

--- a/jinja/jinjify.py
+++ b/jinja/jinjify.py
@@ -15,8 +15,6 @@ TEMPLATE_DIRS = [ os.path.abspath(os.getcwd()),
                   os.path.join(os.getenv('OTS_DOCTOOLS_DIR'), 'jinja'),
                   os.path.join(os.getenv('OTS_DOCTOOLS_DIR'), 'latex')]
 
-import click
-import frontmatter
 import jinja2
 import subprocess
 import re
@@ -25,6 +23,10 @@ import sys
 regex = {'sub':r'[^a-zA-Z0-9.,?!]'}
 for r in regex:
     regex[r] = re.compile(regex[r])
+
+def run_p(text, meta):
+    return meta != {}
+
 
 # We're not using this func right now, but I do want to add markdown
 # support back in later, once I've figure out how to fit it in
@@ -39,80 +41,10 @@ def md2tex(string):
     )
     return p.communicate(input=string.encode('UTF-8'))[0].decode('UTF-8') 
 
-def redact(args, text):
-    """Go through the list of strings in 'redacted' YAML field.  Treat
-each one as a regex and replace each regex with a LaTeX function that
-prints a censored black box.
-
-    """
-    if not 'redact' in args:
-        return text
+def run(text, meta):
+    """Apply jinja templates to TEXT, using metadata from dict META.
+    Returns rendered text and unchanged META."""
     
-    ## Make a list of places we should censor, taking care to handle
-    ## overlapping matches (we don't want a short match to prevent a
-    ## long match that is a superset to not match)
-    censor = []
-    for pat in args['redacted']:
-        pat = pat.replace(r'\ ', '\s*')
-        pat = re.compile(pat, re.IGNORECASE)
-        for m in pat.finditer(text):
-            span = m.span()
-            for i in range(len(censor)):
-                c = censor[i]
-                if (span and
-                    span[0] < c[1] and
-                    span[1] > c[0]):
-                    censor[i] = (min(c[0], span[0]), max(c[1], span[1]))
-                    span = None
-            if span:
-                censor.append(span)
-
-    # Replace any matches with censored X boxes
-    censor = sorted(censor)
-    retext = ""
-    last = 0
-    for c in censor:
-        retext += text[last:c[0]] + r"\censor{XXXX}"
-        last = c[1]
-    text = retext + text[last:]
-
-    
-    # Don't censor in the acronym definition section.  It breaks
-    # LaTeX.  Just remove the line instead.
-    state = None
-    lines = text.split("\n")
-    for l in range(len(lines)):
-        line = lines[l].strip()
-        if "Legacy" in line:
-            print(line)
-        if line.startswith("\\begin{acronym}"):
-            state = "in acronyms"
-        elif state == "in acronyms" and "\\censor{" in line:
-                lines[l] = ""
-        elif line.startswith("\end{acronym}"):
-            state = "done"
-    text = "\n".join(lines)
-    
-    return text
-
-@click.command()
-@click.argument('filename')
-@click.option('--option', '-o', nargs=2, multiple=True, default='', help='Variables and their values.')
-@click.option('--output')
-#@click.option('--redact', 'redacted', flag_value=True, default=False)
-def jinjify(filename, option, output):
-    """Read and parse yaml+latex file."""
-    doc = frontmatter.load(filename)
-    template = doc.content # treat latex as a jinja2 template
-    args = doc.metadata    # treat yaml frontmatter as jinja2 arguments
-
-    # Pass the environment in as a var
-    args['environment'] = os.environ
-
-    # Pass to jinja any options submitted on the command line
-    for o in option:
-        args[o[0]] = o[1]
-
     # Make a version of a Jinja2 parser that plays nice with LaTeX
     latex_jinja_env = jinja2.Environment(
             block_start_string = '\BLOCK{',
@@ -127,26 +59,17 @@ def jinjify(filename, option, output):
             autoescape = False,
             loader = jinja2.ChoiceLoader([
                 jinja2.FileSystemLoader(TEMPLATE_DIRS),
-                jinja2.DictLoader({'jinjify_me.ltx':template,
+                jinja2.DictLoader({'jinjify_me.ltx':text,
                                 'proposal.ltx':'test'}),
             ])
         )
-
+    
     template = latex_jinja_env.get_template('jinjify_me.ltx')
-
+    
     # Quick example of calling a python func from our template. Evoke with
     # \VAR{testfunc()}
     #def testfunc():
     #    return u'TEST'
     #template.globals.update(testfunc=testfunc)
 
-    rendered = template.render(**args)
-    rendered = redact(args, rendered)
-
-    if output:
-        with open(output, 'w') as fh:
-            fh.write(rendered)
-    else:
-        print(rendered)
-if __name__ == '__main__':
-    jinjify()
+    return template.render(**meta), meta

--- a/jinja/jinjify.py
+++ b/jinja/jinjify.py
@@ -19,7 +19,12 @@ import click
 import frontmatter
 import jinja2
 import subprocess
+import re
 import sys
+
+regex = {'sub':r'[^a-zA-Z0-9.,?!]'}
+for r in regex:
+    regex[r] = re.compile(regex[r])
 
 # We're not using this func right now, but I do want to add markdown
 # support back in later, once I've figure out how to fit it in
@@ -34,10 +39,68 @@ def md2tex(string):
     )
     return p.communicate(input=string.encode('UTF-8'))[0].decode('UTF-8') 
 
+def redact(args, text):
+    """Go through the list of strings in 'redacted' YAML field.  Treat
+each one as a regex and replace each regex with a LaTeX function that
+prints a censored black box.
+
+    """
+    if not 'redact' in args:
+        return text
+    
+    ## Make a list of places we should censor, taking care to handle
+    ## overlapping matches (we don't want a short match to prevent a
+    ## long match that is a superset to not match)
+    censor = []
+    for pat in args['redacted']:
+        pat = pat.replace(r'\ ', '\s*')
+        pat = re.compile(pat, re.IGNORECASE)
+        for m in pat.finditer(text):
+            span = m.span()
+            for i in range(len(censor)):
+                c = censor[i]
+                if (span and
+                    span[0] < c[1] and
+                    span[1] > c[0]):
+                    censor[i] = (min(c[0], span[0]), max(c[1], span[1]))
+                    span = None
+            if span:
+                censor.append(span)
+
+    # Replace any matches with censored X boxes
+    censor = sorted(censor)
+    retext = ""
+    last = 0
+    for c in censor:
+        retext += text[last:c[0]] + r"\censor{XXXX}"
+        last = c[1]
+    text = retext + text[last:]
+
+    
+    # Don't censor in the acronym definition section.  It breaks
+    # LaTeX.  Just remove the line instead.
+    state = None
+    lines = text.split("\n")
+    for l in range(len(lines)):
+        line = lines[l].strip()
+        if "Legacy" in line:
+            print(line)
+        if line.startswith("\\begin{acronym}"):
+            state = "in acronyms"
+        elif state == "in acronyms" and "\\censor{" in line:
+                lines[l] = ""
+        elif line.startswith("\end{acronym}"):
+            state = "done"
+    text = "\n".join(lines)
+    
+    return text
+
 @click.command()
 @click.argument('filename')
 @click.option('--option', '-o', nargs=2, multiple=True, default='', help='Variables and their values.')
-def jinjify(filename, option):
+@click.option('--output')
+#@click.option('--redact', 'redacted', flag_value=True, default=False)
+def jinjify(filename, option, output):
     """Read and parse yaml+latex file."""
     doc = frontmatter.load(filename)
     template = doc.content # treat latex as a jinja2 template
@@ -49,7 +112,7 @@ def jinjify(filename, option):
     # Pass to jinja any options submitted on the command line
     for o in option:
         args[o[0]] = o[1]
-        
+
     # Make a version of a Jinja2 parser that plays nice with LaTeX
     latex_jinja_env = jinja2.Environment(
             block_start_string = '\BLOCK{',
@@ -78,6 +141,12 @@ def jinjify(filename, option):
     #template.globals.update(testfunc=testfunc)
 
     rendered = template.render(**args)
-    print(rendered)
+    rendered = redact(args, rendered)
+
+    if output:
+        with open(output, 'w') as fh:
+            fh.write(rendered)
+    else:
+        print(rendered)
 if __name__ == '__main__':
     jinjify()

--- a/jinja/jinjify.py
+++ b/jinja/jinjify.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+"""This script takes two parameters.  The first is a latex file with
+yaml frontmatter.  The body after the frontmatter is latex use as a
+jinja2 template.  We pass the yaml frontmatter to that jinja2 template
+and print the results.
+
+"""
+import os
+
+# Search path for Jinja templates, in order of preference
+TEMPLATE_DIRS = [ os.path.abspath(os.getcwd()),
+                  os.path.join(os.getenv('OTSDIR'), 'forms', 'jinja'),
+                  os.path.join(os.getenv('OTSDIR'), 'forms', 'latex'),
+                  os.path.join(os.getenv('OTS_DOCTOOLS_DIR'), 'jinja'),
+                  os.path.join(os.getenv('OTS_DOCTOOLS_DIR'), 'latex')]
+
+import click
+import frontmatter
+import jinja2
+import subprocess
+import sys
+
+# We're not using this func right now, but I do want to add markdown
+# support back in later, once I've figure out how to fit it in
+# appropriately.
+def md2tex(string):
+    """Pass markdown STRING through pandoc and return the resulting latex"""
+    p = subprocess.Popen("pandoc -f markdown -t latex",
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stdin=subprocess.PIPE,
+                         stderr=subprocess.PIPE
+    )
+    return p.communicate(input=string.encode('UTF-8'))[0].decode('UTF-8') 
+
+@click.command()
+@click.argument('filename')
+@click.option('--option', '-o', nargs=2, multiple=True, default='', help='Variables and their values.')
+def jinjify(filename, option):
+    """Read and parse yaml+latex file."""
+    doc = frontmatter.load(filename)
+    template = doc.content # treat latex as a jinja2 template
+    args = doc.metadata    # treat yaml frontmatter as jinja2 arguments
+
+    # Pass the environment in as a var
+    args['environment'] = os.environ
+
+    # Pass to jinja any options submitted on the command line
+    for o in option:
+        args[o[0]] = o[1]
+        
+    # Make a version of a Jinja2 parser that plays nice with LaTeX
+    latex_jinja_env = jinja2.Environment(
+            block_start_string = '\BLOCK{',
+            block_end_string = '}',
+            variable_start_string = '\VAR{',
+            variable_end_string = '}',
+            comment_start_string = '\#{',
+            comment_end_string = '}',
+            line_statement_prefix = '%%',
+            line_comment_prefix = '%#',
+            trim_blocks = True,
+            autoescape = False,
+            loader = jinja2.ChoiceLoader([
+                jinja2.FileSystemLoader(TEMPLATE_DIRS),
+                jinja2.DictLoader({'jinjify_me.ltx':template,
+                                'proposal.ltx':'test'}),
+            ])
+        )
+
+    template = latex_jinja_env.get_template('jinjify_me.ltx')
+
+    # Quick example of calling a python func from our template. Evoke with
+    # \VAR{testfunc()}
+    #def testfunc():
+    #    return u'TEST'
+    #template.globals.update(testfunc=testfunc)
+
+    rendered = template.render(**args)
+    print(rendered)
+if __name__ == '__main__':
+    jinjify()

--- a/latex/otsreport.cls
+++ b/latex/otsreport.cls
@@ -128,27 +128,7 @@
   {\setlength{\headheight}{10pt}\setlength{\headsep}{30pt}
     \renewcommand{\@oddhead}{\usebox{\firmhead}}
   }
-
-% Some stuff for the draft version
-\usepackage{eso-pic}
-%\usepackage[yyyymmdd,hhmmss]{datetime}
-\usepackage{datetime2}
-\usepackage{catchfile}
-\newcommand{\getenv}[2][]{%
-  \CatchFileEdef{\temp}{"|kpsewhich --var-value #2"}{}%
-  \if\relax\detokenize{#1}\relax\temp\else\let#1\temp\fi}
-\getenv[\DRAFT]{DRAFT}
-\getenv[\JOBNAME]{JOBNAME}
-\getenv[\SVNREVISION]{SVNREVISION}
-\usepackage{xstring}
-
-%% If this is a draft, add a draft watermark
-\IfSubStr{\DRAFT}{yes}{
-  \usepackage{draftwatermark}
-  \SetWatermarkText{DRAFT}
-  \SetWatermarkScale{6}
-}{}
-  
+ 
 %% For reference, the 10 default LaTeX font sizes are:
 %%
 %%    \tiny

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import click
+import frontmatter
+import importlib
+import os
+import pkgutil
+import sys
+
+
+def get_plugins(plugin_dir=None):
+    """Load plugins from PLUGIN_DIR and return a dict with the plugin name
+    hashed to the imported plugin.
+
+    PLUGIN_DIR is the name of the dir from which to load plugins.  If
+    it is None, use the plugin dir in the dir that holds this func.
+
+    Plugins are loaded and run in asciibetical order.
+
+    PLUGIN API:
+
+    run_p(text, meta): (required) predicate returns True if this
+    plugin thinks it should run in the pipeline.
+
+    run(text, meta): (required) runs the plugin, returns text, meta
+
+    """
+    if not plugin_dir:
+        plugin_dir = os.path.join(
+            os.path.dirname(
+                os.path.abspath(__file__)), "plugins")
+
+    plugins = {}
+    for fname in sorted(os.listdir(plugin_dir)):
+        if (not fname.endswith(".py")
+            or fname.startswith('.')
+            or '#' in fname):
+            continue
+        spec = importlib.util.spec_from_file_location(fname,
+                                                      os.path.join(plugin_dir, fname)
+                                                      )
+        plugins[fname] = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(plugins[fname])
+    return plugins
+
+@click.command()
+@click.argument('filename')
+@click.option('--output', help="output filename")
+@click.option('--plugin', help="specify just one plugin to run (not implemented)")
+@click.option('--option', '-o', nargs=2, multiple=True, default='', help='Variables and their values.')
+def cli(filename, output, option, plugin):
+    doc = frontmatter.load(filename)
+    text = doc.content
+    meta = doc.metadata
+    meta['input_filename'] = filename
+    meta['output_filename'] = output
+    
+    # Grab the environment too
+    meta['environment'] = os.environ
+
+    # Pass to jinja any options submitted on the command line
+    for o in option:
+        meta[o[0]] = o[1]
+
+    plugins = get_plugins()
+    for p,m in plugins.items():
+        if m.run_p(text, meta):
+           text, meta = m.run(text, meta)
+           
+    if output:
+        with open(output, 'w') as fh:
+            fh.write(text)
+    else:
+        print(text)
+        
+if __name__ == '__main__':
+    cli()

--- a/pipeline/plugins/15_draft.py
+++ b/pipeline/plugins/15_draft.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+"""If we're making a file with 'draft' in the name, enable draft mode"""
+
+def run_p(text, meta):
+    return 'draft' in meta['output_filename']
+
+def run(text, meta):
+    meta['draft']=True
+    return text, meta

--- a/pipeline/plugins/50_jinjify.py
+++ b/pipeline/plugins/50_jinjify.py
@@ -1,0 +1,1 @@
+../../jinja/jinjify.py

--- a/pipeline/plugins/60_redact.py
+++ b/pipeline/plugins/60_redact.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import re
+
+def redact(text, meta):
+    """Go through the list of strings in 'redacted' YAML field of dict
+META.  Treat each one as a regex and replace each regex in string TEXT
+with a LaTeX function that prints a censored black box.
+
+    """
+    
+    if not 'redacted' in meta:
+        return text, meta
+    
+    ## Make a list of places we should censor, taking care to handle
+    ## overlapping matches (we don't want a short match to prevent a
+    ## long match that is a superset to not match)
+    censor = []
+    for pat in meta['redacted']:
+        pat = pat.replace(r'\ ', '\s*')
+        pat = re.compile(pat, re.IGNORECASE)
+        for m in pat.finditer(text):
+            span = m.span()
+            for i in range(len(censor)):
+                c = censor[i]
+                if (span and
+                    span[0] < c[1] and
+                    span[1] > c[0]):
+                    censor[i] = (min(c[0], span[0]), max(c[1], span[1]))
+                    span = None
+            if span:
+                censor.append(span)
+
+    # Replace any matches with censored X boxes
+    censor = sorted(censor)
+    retext = ""
+    last = 0
+    for c in censor:
+        retext += text[last:c[0]] + r"\censor{XXXX}"
+        last = c[1]
+    text = retext + text[last:]
+
+    
+    # Don't censor in the acronym definition section.  It breaks
+    # LaTeX.  Just remove the line instead.
+    state = None
+    lines = text.split("\n")
+    for l in range(len(lines)):
+        line = lines[l].strip()
+        if "Legacy" in line:
+            print(line)
+        if line.startswith("\\begin{acronym}"):
+            state = "in acronyms"
+        elif state == "in acronyms" and "\\censor{" in line:
+                lines[l] = ""
+        elif line.startswith("\end{acronym}"):
+            state = "done"
+    text = "\n".join(lines)
+    
+    return text, meta
+
+def run_p(text, meta):
+    return meta['output_filename'].endswith('.redacted.tex')
+
+def run(text, meta):
+    text, meta = redact(text, meta)
+    return text, meta

--- a/pipeline/plugins/60_redact.py
+++ b/pipeline/plugins/60_redact.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+""" If we're making a file called foo.redacted.tex, do redactions."""
+
 import re
 
 def redact(text, meta):

--- a/pipeline/plugins/60_redact.py
+++ b/pipeline/plugins/60_redact.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-""" If we're making a file called foo.redacted.tex, do redactions."""
+""" If we're making a file with 'redacted' in the filename, do redactions."""
 
 import re
 
@@ -62,7 +62,7 @@ with a LaTeX function that prints a censored black box.
     return text, meta
 
 def run_p(text, meta):
-    return meta['output_filename'].endswith('.redacted.tex')
+    return 'redacted' in meta['output_filename']
 
 def run(text, meta):
     text, meta = redact(text, meta)


### PR DESCRIPTION
Add Jinja capabilities and redaction too.

Put the draft, redaction and jinja stuff into a pluggable pipeline that runs plugins on an as-needed basis.  If it finds YAML frontmatter, it tries jinja.  If the output filename is *.redacted.tex, it tries to redact.  This allows us to simplify our makefile a little.

Tested on some legacy .ltx files as well as newer ones.  They build, so @kfogel I'm asking you to test on your docs and merge if it works.

This is a lot of changes to merge at once, but they're a bit more granular in the pipeline branch.